### PR TITLE
Refactor debate engine with stance enum and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+```markdown
+# LLMDebate — 3 Super Simple LLMs That Debate Each Other
+
+This small demo runs a debate between three toy "LLM" models (no external APIs required).
+Each model is a lightweight, template-driven generator with different personalities:
+Proponent (pro), Opponent (con), and Moderator (neutral).
+
+New behavior:
+- The user supplies the topic (first input).
+- A starting AI is chosen at random.
+- On each subsequent turn the next speaker is chosen so their stance is adversarial to
+  the previous non-neutral stance (so no two consecutive responses share the same opinion).
+- If the previous speaker was neutral (Moderator), the next speaker is chosen randomly to be
+  pro or con.
+- If multiple eligible models could speak, the selection is random.
+- Moderator remains neutral: it summarizes or reframes rather than taking a pro/con stance.
+
+How to run
+1. Make sure you have Python 3.8+ installed.
+2. Run the CLI:
+   python debate.py "Should we colonize Mars?" --turns 6
+
+Options
+- --turns N   : total number of speaker turns (default 6)
+- --seed S    : optional integer seed for deterministic randomness (useful for reproducible runs)
+
+Example:
+   $ python debate.py "Universal basic income?" --turns 5 --seed 42
+
+Notes
+- The models here are intentionally tiny and deterministic with small randomness to vary wording.
+- You can extend models.py to wrap real LLM APIs (OpenAI, local models) if you want real generation.
+```

--- a/debate.py
+++ b/debate.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Tiny CLI to run a debate between three toy LLMs with adversarial turn selection.
+
+Usage:
+    python debate.py "Should we colonize Mars?" --turns 6 --seed 123
+"""
+import argparse
+import sys
+import random
+from typing import List, Optional, Tuple
+
+from models import Moderator, Opponent, Proponent, SimpleLLM, Stance
+
+
+def make_models(seed: Optional[int] = None) -> List[SimpleLLM]:
+    """Instantiate the default trio of debaters.
+
+    Supplying a seed makes all random choices reproducible which is useful for
+    debugging or demonstrations. Each model gets a unique offset seed so they
+    behave slightly differently while still being deterministic.
+    """
+
+    a = Proponent(name="Argus (Pro)", tone="passionate", persuasion=0.8, seed=seed)
+    b = Opponent(
+        name="Boreas (Con)",
+        tone="skeptical",
+        persuasion=0.7,
+        seed=seed and seed + 1,
+    )
+    c = Moderator(
+        name="Clio (Moderator)",
+        tone="measured",
+        persuasion=0.5,
+        seed=seed and seed + 2,
+    )
+    return [a, b, c]
+
+
+def _models_by_stance(models: List[SimpleLLM], stance: Stance) -> List[Tuple[int, SimpleLLM]]:
+    """Return ``(index, model)`` pairs for all models that match ``stance``."""
+
+    return [(i, m) for i, m in enumerate(models) if m.stance == stance]
+
+
+def _select_next_index(
+    models: List[SimpleLLM],
+    current_idx: int,
+    last_non_neutral: Optional[Stance],
+    rng: random.Random,
+) -> int:
+    """Decide which model should speak next.
+
+    The rules enforce an adversarial flow: a "pro" statement is followed by a
+    "con" one and vice versa. A neutral moderator may be followed by either.
+    If no model of the required stance exists, any other model is chosen.
+    """
+
+    current_model = models[current_idx]
+
+    if current_model.stance == Stance.PRO:
+        required = Stance.CON
+    elif current_model.stance == Stance.CON:
+        required = Stance.PRO
+    else:  # current speaker is neutral
+        if last_non_neutral == Stance.PRO:
+            required = Stance.CON
+        elif last_non_neutral == Stance.CON:
+            required = Stance.PRO
+        else:
+            required = rng.choice([Stance.PRO, Stance.CON])
+
+    candidates = _models_by_stance(models, required)
+    if not candidates:
+        # Fallback: choose any model other than the current one.
+        candidates = [(i, m) for i, m in enumerate(models) if i != current_idx]
+
+    return rng.choice(candidates)[0]
+
+
+def run_debate(topic: str, turns: int = 6, seed: Optional[int] = None) -> None:
+    """Run a debate for ``topic`` between the default models.
+
+    Args:
+        topic: The question or statement being debated.
+        turns: Total number of speaker turns to execute.
+        seed: Optional random seed for deterministic behavior.
+    """
+
+    models = make_models(seed=seed)
+    rng = random.Random(seed)
+
+    print("="*80)
+    print(f"Debate topic: {topic}")
+    print("="*80)
+
+    # Select the initial speaker at random. ``current_idx`` will keep track of
+    # the speaker for each turn.
+    current_idx = rng.randrange(len(models))
+
+    # ``last_non_neutral`` remembers the last pro/con stance so a moderator can
+    # respond with an opposing viewpoint. ``last_output`` stores the full text of
+    # the previous message so the moderator can summarize it.
+    last_non_neutral: Optional[Stance] = None
+    last_output: Optional[str] = None
+
+    for t in range(1, turns + 1):
+        model = models[current_idx]
+
+        # Pass the previous output as context to allow summarization or rebuttal.
+        out = model.generate(topic, context=last_output)
+        last_output = out
+
+        print(f"\n--- Turn {t} ---")
+        print(f"\n{model.name} ({model.stance.value}):")
+        print(out)
+
+        if model.stance in (Stance.PRO, Stance.CON):
+            last_non_neutral = model.stance
+
+        current_idx = _select_next_index(models, current_idx, last_non_neutral, rng)
+
+    print("\n" + "="*80)
+    print("Debate ended.")
+    print("="*80)
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Tiny LLM debate CLI with adversarial turns")
+    parser.add_argument("topic", help="Topic to debate (wrap in quotes)")
+    parser.add_argument("--turns", type=int, default=6, help="Number of speaker turns")
+    parser.add_argument("--seed", type=int, default=None, help="Optional RNG seed for reproducible runs")
+    args = parser.parse_args(argv)
+    run_debate(args.topic, turns=args.turns, seed=args.seed)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/models.py
+++ b/models.py
@@ -1,0 +1,195 @@
+"""
+Toy LLM models for a tiny debate demo.
+
+Each model is extremely simple: it uses templates + small randomness to produce
+plausible-sounding arguments. No external API is needed.
+
+The file intentionally aims to be beginner friendly; heavy commenting is used to
+explain the design and make future modifications easier.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+import random
+import textwrap
+from typing import List, Optional
+
+
+class Stance(str, Enum):
+    """Enum of possible positions a model can take in the debate."""
+
+    PRO = "pro"
+    CON = "con"
+    NEUTRAL = "neutral"
+
+
+@dataclass
+class SimpleLLM:
+    """Minimalistic language model used by the debate engine.
+
+    Attributes:
+        name: Name displayed when the model speaks.
+        tone: Short descriptor inserted into templates (e.g., "passionate").
+        persuasion: 0..1 value representing how persuasive the model tries to be.
+        seed: Optional random seed so outputs can be made reproducible. Each model
+            gets its own independent pseudo random generator.
+    """
+
+    name: str
+    tone: str
+    persuasion: float
+    seed: Optional[int] = None
+    # ``seed_state`` is created after initialization because ``random.Random``
+    # cannot be represented directly as a dataclass default.
+    seed_state: random.Random = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # Clamp persuasion to the valid range and create an RNG using the seed.
+        self.persuasion = max(0.0, min(1.0, self.persuasion))
+        self.seed_state = random.Random(self.seed)
+
+    # ------------------------------------------------------------------
+    # Core interface
+    # ------------------------------------------------------------------
+    @property
+    def stance(self) -> Stance:
+        """The position taken by this model (subclasses override)."""
+
+        return Stance.NEUTRAL
+
+    def _pick(self, options: List[str]) -> str:
+        """Helper to deterministically pick from a list using the model RNG."""
+
+        return self.seed_state.choice(options)
+
+    def generate(self, topic: str, context: Optional[str] = None) -> str:
+        """Produce a short argument for ``topic``.
+
+        Args:
+            topic: Subject under debate.
+            context: Previous utterance, which allows a model to reference or
+                summarize prior content.
+
+        Returns:
+            A formatted string containing the model's statement.
+        """
+
+        # Simple templates provide varied yet deterministic phrasing.
+        opening = self._pick([
+            "I believe",
+            "It's clear to me",
+            "From my point of view",
+            "Consider that",
+        ])
+
+        stance_phrase = self._stance_phrase(topic, context)
+        reasons = self._reasons(topic, context)
+
+        closing = self._pick([
+            "That's why I'm convinced.",
+            "This is the heart of the matter.",
+            "In short, the evidence points there.",
+            "Ultimately, the conclusion follows.",
+        ])
+
+        output = f"{opening} {stance_phrase} {reasons} {closing}"
+        # ``textwrap.fill`` wraps the string nicely for terminal output.
+        return textwrap.fill(output, width=80)
+
+    # The following methods are intentionally left abstract. Subclasses provide
+    # concrete implementations tailored to their perspective.
+    def _stance_phrase(self, topic: str, context: Optional[str]) -> str:
+        raise NotImplementedError
+
+    def _reasons(self, topic: str, context: Optional[str]) -> str:
+        raise NotImplementedError
+
+
+class Proponent(SimpleLLM):
+    @property
+    def stance(self) -> Stance:
+        return Stance.PRO
+
+    def _stance_phrase(self, topic, context):
+        return f"we should support {topic}"
+
+    def _reasons(self, topic, context):
+        candidates = [
+            f"{topic} would unlock new opportunities and drive innovation.",
+            f"{topic} addresses urgent challenges and creates long-term value.",
+            f"{topic} empowers people and expands our options."
+        ]
+        reason = self._pick(candidates)
+        modifier = self._pick([
+            "Moreover,",
+            "Importantly,",
+            "Significantly,"
+        ])
+        confidence = self._confidence_word()
+        return f"{modifier} {reason} {confidence}"
+
+    def _confidence_word(self):
+        if self.persuasion > 0.75:
+            return "This is undeniable."
+        if self.persuasion > 0.4:
+            return "This is convincing."
+        return "This seems plausible."
+
+
+class Opponent(SimpleLLM):
+    @property
+    def stance(self) -> Stance:
+        return Stance.CON
+
+    def _stance_phrase(self, topic, context):
+        return f"we should be cautious about {topic}"
+
+    def _reasons(self, topic, context):
+        candidates = [
+            f"{topic} carries risks that could be overlooked.",
+            f"{topic} might create unintended negative consequences.",
+            f"{topic} could be costly and favor the wrong actors."
+        ]
+        reason = self._pick(candidates)
+        modifier = self._pick([
+            "However,",
+            "On the other hand,",
+            "Yet,"
+        ])
+        caution = self._caution_word()
+        return f"{modifier} {reason} {caution}"
+
+    def _caution_word(self):
+        if self.persuasion > 0.75:
+            return "We must not rush in."
+        if self.persuasion > 0.4:
+            return "We should investigate further."
+        return "We should proceed carefully."
+
+
+class Moderator(SimpleLLM):
+    @property
+    def stance(self) -> Stance:
+        return Stance.NEUTRAL
+
+    def _stance_phrase(self, topic, context):
+        # Moderator summarizes or reframes; avoid taking the same pro/con stance.
+        if context:
+            # Provide a short summary of the last message without endorsing.
+            summary = context[:140].rstrip('.')
+            return f"I'll summarize: {summary}"
+        return f"let's examine {topic} from several angles"
+
+    def _reasons(self, topic, context):
+        candidates = [
+            "The pros and cons deserve clear comparison.",
+            "Key trade-offs need to be weighed transparently.",
+            "We should ask who benefits and who bears the cost."
+        ]
+        reason = self._pick(candidates)
+        suggestion = self._pick([
+            "A pilot program might help.",
+            "Clear metrics could guide decisions.",
+            "Stakeholder input is essential."
+        ])
+        return f"{reason} {suggestion}"


### PR DESCRIPTION
## Summary
- refactor toy LLM models to use a `Stance` enum and dataclass-based `SimpleLLM`
- modularize speaker selection and add type hints and comments for scalability

## Testing
- `python -m py_compile models.py debate.py`
- `python debate.py "Test topic" --turns 3 --seed 42`


------
https://chatgpt.com/codex/tasks/task_e_68b58fe5641c83258c5f5821df8b34eb